### PR TITLE
Fix Firebase storage bucket reference

### DIFF
--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -8,7 +8,7 @@ export const environment = {
     apiKey: "AIzaSyBAjZIJobO3KpIYuQMJ5D9y6Wwfvvk-OHE",
     authDomain: "friendlychat-15567.firebaseapp.com",
     projectId: "friendlychat-15567",
-    storageBucket: "friendlychat-15567.firebasestorage.app",
+    storageBucket: "friendlychat-15567.appspot.com",
     messagingSenderId: "511919141787",
     appId: "1:511919141787:web:dd00faffe2469053fce73e"
   }


### PR DESCRIPTION
## Summary
- correct `storageBucket` domain in environment config

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_685a31be3b248322ae6620a5ef66ab4b